### PR TITLE
passport-oauth@1.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "./lib/passport-baidu",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth": "1.0.x"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
update to the latest version of `passport-oauth` (there are no breaking changes)
